### PR TITLE
レスポンシブデザインも完成

### DIFF
--- a/esoraMenu.css
+++ b/esoraMenu.css
@@ -581,6 +581,13 @@ small{
   color: transparent;
   font-family: "Palanquin Dark";
 }
+.cutMenuWrap {
+	margin-top: 40px;
+	font-size: 0;
+	padding: 20px 10px 0 10px;
+	/* border: solid 1px rgba(0, 0, 0, 0.5); */
+	box-shadow: -1px 2px 6px 1px rgba(0, 0, 0, 0.4);
+}
 .menuImageWrap img {
 	display: block;
 	margin: 0 0 0 30px;
@@ -591,16 +598,8 @@ small{
   display: inline-block;
   width: 330px;
 }
-.cutMenuWrap {
-	margin-top: 40px;
-	font-size: 0;
-	padding: 20px 1% 0 1%;
-	border: solid 1px rgba(0, 0, 0, 0.5);
-	box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.4);
-}
 .menuItemWrap {
   width: 750px;
-  min-height: 350px;
   display: inline-block;
   vertical-align: top;
 }
@@ -617,12 +616,13 @@ small{
 .menuItemWrap table {
 	width: 100%;
 	border-collapse: collapse;
+
 }
 .menuItemWrap tr:hover {
 	background-color: rgba(0, 0, 0, 0.1);
 }
 .menuItemWrap td {
-  margin: 25px;
+  margin: 25px 20px;
 	font-size: 14px;
 	color: rgba(0, 0, 0, 0.6);
 }
@@ -639,6 +639,7 @@ small{
 }
 .buttonWrap a {
 	display: block;
+	width: 500px;
 	font-size: 14px;
   position: relative;
   text-decoration: none;
@@ -646,13 +647,11 @@ small{
   font-weight: bold;
   background-color: transparent;
   padding: 10px 0;
-	margin-left: 530px;
-	margin-right: 50px;
+	margin: 0 50px 0 auto;
   border: 1px solid rgba(0, 0, 0, 0.7);
   border-radius: 10px;
   cursor: pointer;
 }
-
 .buttonWrap a::after {
   content: "";
   position: absolute;
@@ -673,4 +672,52 @@ small{
 .buttonWrap a:hover::after {
 	border-top: 1px solid white;
 	border-right: 1px solid white;
+}
+.buttonWrap a:active {
+	background-color: rgba(0, 0, 0, 0.1);
+	border-color: rgba(0, 0, 0, 0.1);
+}
+
+@media screen and (max-width: 1099px) {
+	.cutMenuWrap {
+		width: 95%;
+	}
+	.menuItemWrap {
+		width: calc(100% - 330px);
+	}
+	.menuItemWrap td:first-of-type {
+		padding: 0;
+	}
+	.buttonWrap a {
+		width: calc(100% - 380px);
+	}
+}
+
+@media screen and (max-width: 767px) {
+	.cutMenuWrap {
+		box-shadow: none;
+	}
+	.menuImageWrap {
+		display: none;
+	}
+	.menuItemWrap {
+		width: 100%;
+		text-align: center;
+	}
+	.menuItemWrap h3 {
+		padding: 5px 0;
+		border-top: solid 1px black;
+		border-bottom: solid 1px black;
+	}
+	.menuItemWrap td:first-of-type {
+		text-align: left;
+		padding-left: 30px;
+	}
+	.price {
+		padding-right: 10px;
+	}
+	.buttonWrap a {
+		margin: 0 auto;
+		width: calc(100% - 60px);
+	}
 }


### PR DESCRIPTION
メニューの塊の枠線をなくした。

ウィンドウサイズが767px〜1099px(1079pxにメニューの塊の左右パディング10pxを考慮した)の場合は、メニュー項目の横幅が可変になるよう％指定した。

767px以下の場合は、画像をなくして、メニューの塊の影もなくした。